### PR TITLE
changing defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ component entry point:
 </mv-media-viewer>  
 ```
 
-The `actionEvents` property is an instance of the `ActionEvents` class which acts like an event bus. The `actionEvents` instance will contain subscribable event streams for toolbar actions such as zoom, rotate and search. 
+The optional `actionEvents` property is an instance of the `ActionEvents` class which acts like an event bus. The `actionEvents` instance will contain subscribable event streams for toolbar actions such as zoom, rotate and search. Can be used to interact with the viewer in case the default toolbar is disabled. 
 
 ### Toolbar
 

--- a/projects/media-viewer/src/lib/media-viewer/media-viewer.component.ts
+++ b/projects/media-viewer/src/lib/media-viewer/media-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import {Component, Input} from '@angular/core';
 import { Subject } from 'rxjs';
 import { ActionEvents } from './model/action-events';
 import { ToolbarToggles } from './model/toolbar-toggles';
@@ -14,7 +14,7 @@ export class MediaViewerComponent {
   @Input() url = '';
   @Input() downloadFileName = null;
   @Input() contentType: string;
-  @Input() actionEvents: ActionEvents;
+  @Input() actionEvents = new ActionEvents();
   @Input() showToolbar = true;
 
   toolbarToggles = new ToolbarToggles();

--- a/src/app/sandbox-webapp/sandbox-webapp.component.html
+++ b/src/app/sandbox-webapp/sandbox-webapp.component.html
@@ -43,19 +43,16 @@
         <mv-media-viewer *ngIf="documentTypeToShow === 'pdf'"
                          [url]="'assets/example.pdf'"
                          [downloadFileName]="'example.pdf'"
-                         [actionEvents]=actionEvents
                          [showToolbar]="showToolbar"
                          [contentType]="'pdf'">
         </mv-media-viewer>
         <mv-media-viewer *ngIf="documentTypeToShow === 'image'"
                          [url]="'assets/example.jpg'"
-                         [actionEvents]=actionEvents
                          [showToolbar]="showToolbar"
                          [downloadFileName]="'example.jpg'"
                          [contentType]="'image'">
         </mv-media-viewer>
         <mv-media-viewer *ngIf="documentTypeToShow === 'unsupported'"
-                         [actionEvents]=actionEvents
                          [url]="'assets/unsupported.txt'"
                          [downloadFileName]="'unsupported.txt'"
                          [showToolbar]="showToolbar"

--- a/src/app/sandbox-webapp/sandbox-webapp.component.ts
+++ b/src/app/sandbox-webapp/sandbox-webapp.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { ActionEvents } from '../../../projects/media-viewer/src/lib/media-viewer/model/action-events';
 
 @Component({
   selector: 'app-sandbox-webapp',
@@ -9,12 +8,7 @@ import { ActionEvents } from '../../../projects/media-viewer/src/lib/media-viewe
 export class SandboxWebappComponent {
 
   documentTypeToShow = 'nonDM_PDF';
-  actionEvents: ActionEvents;
   showToolbar = true;
-
-  constructor() {
-    this.actionEvents = new ActionEvents();
-  }
 
   toggleDocumentSelection(selectedDocumentType: string) {
     this.documentTypeToShow = selectedDocumentType;


### PR DESCRIPTION



### Change description ###

I moved the init of ActionEvents to media-viewer. It should be an optional action if a consumer chooses not to use the toolbar.

