### PR TITLE
error message component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5126,7 +5126,6 @@
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5302,8 +5301,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5381,8 +5379,7 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/projects/media-viewer/src/lib/media-viewer.module.ts
+++ b/projects/media-viewer/src/lib/media-viewer.module.ts
@@ -11,6 +11,7 @@ import { MediaViewerService } from './media-viewer/service/media-viewer.service'
 import { EmLoggerService } from './logging/em-logger.service';
 import { ToolbarModule } from './media-viewer/toolbar/toolbar.module';
 import { PdfJsWrapperFactory } from './media-viewer/viewers/pdf-viewer/pdf-js/pdf-js-wrapper.provider';
+import {ErrorMessageComponent} from './media-viewer/viewers/error-message/error.message.component';
 
 @NgModule({
   imports: [
@@ -18,18 +19,20 @@ import { PdfJsWrapperFactory } from './media-viewer/viewers/pdf-viewer/pdf-js/pd
     CommonModule,
     FormsModule,
     HttpClientModule,
-    ToolbarModule
+    ToolbarModule,
   ],
   declarations: [
     PdfViewerComponent,
     ImageViewerComponent,
     UnsupportedViewerComponent,
     MediaViewerComponent,
+    ErrorMessageComponent
   ],
   entryComponents: [
     PdfViewerComponent,
     ImageViewerComponent,
     UnsupportedViewerComponent,
+    ErrorMessageComponent
 ],
   providers: [
     PdfJsWrapperFactory,
@@ -37,7 +40,8 @@ import { PdfJsWrapperFactory } from './media-viewer/viewers/pdf-viewer/pdf-js/pd
     EmLoggerService
   ],
   exports: [
-    MediaViewerComponent
+    MediaViewerComponent,
+    ErrorMessageComponent
 ]
 })
 export class MediaViewerModule { }

--- a/projects/media-viewer/src/lib/media-viewer.module.ts
+++ b/projects/media-viewer/src/lib/media-viewer.module.ts
@@ -40,8 +40,7 @@ import {ErrorMessageComponent} from './media-viewer/viewers/error-message/error.
     EmLoggerService
   ],
   exports: [
-    MediaViewerComponent,
-    ErrorMessageComponent
+    MediaViewerComponent
 ]
 })
 export class MediaViewerModule { }

--- a/projects/media-viewer/src/lib/media-viewer/media-viewer.component.html
+++ b/projects/media-viewer/src/lib/media-viewer/media-viewer.component.html
@@ -45,12 +45,6 @@
                            [downloadFileName]="downloadFileName"
                            [downloadOperation]="actionEvents?.download | async">
     </mv-unsupported-viewer>
-    <div class="grid-row">
-      <div *ngIf="error"  class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
-        <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">There was an error while loading your document.</h2>
-        <p>Response status was {{error.status}}.</p>
-      </div>
-    </div>
   </div>
 </div>
 

--- a/projects/media-viewer/src/lib/media-viewer/media-viewer.component.spec.ts
+++ b/projects/media-viewer/src/lib/media-viewer/media-viewer.component.spec.ts
@@ -9,6 +9,7 @@ import {
   PdfViewerToolbarButtons,
   UnsupportedViewerToolbarButtons
 } from './model/toolbar-button-toggles';
+import {ErrorMessageComponent} from './viewers/error-message/error.message.component';
 
 describe('MediaViewerComponent', () => {
   let component: MediaViewerComponent;
@@ -20,7 +21,8 @@ describe('MediaViewerComponent', () => {
         MediaViewerComponent,
         PdfViewerComponent,
         ImageViewerComponent,
-        UnsupportedViewerComponent
+        UnsupportedViewerComponent,
+        ErrorMessageComponent
       ],
       imports: [ToolbarModule]
     })

--- a/projects/media-viewer/src/lib/media-viewer/media-viewer.component.ts
+++ b/projects/media-viewer/src/lib/media-viewer/media-viewer.component.ts
@@ -19,7 +19,6 @@ export class MediaViewerComponent implements OnInit {
   @Input() toolbarButtonToggles: ToolbarButtonToggles;
 
   currentPageChanged = new Subject<SetCurrentPageOperation>();
-  error: any;
 
   private supportedContentTypes = ['pdf', 'image'];
 

--- a/projects/media-viewer/src/lib/media-viewer/viewers/error-message/error-message.component.html
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/error-message/error-message.component.html
@@ -1,0 +1,5 @@
+<div class="error-container">
+
+  <div class="error-message">{{errorMessage}}</div>
+
+</div>

--- a/projects/media-viewer/src/lib/media-viewer/viewers/error-message/error-message.component.scss
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/error-message/error-message.component.scss
@@ -1,0 +1,7 @@
+.error-container {
+  .error-message {
+    text-align: center;
+    margin-top: 1em;
+    font-size: 2em;
+  }
+}

--- a/projects/media-viewer/src/lib/media-viewer/viewers/error-message/error-message.component.spec.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/error-message/error-message.component.spec.ts
@@ -1,0 +1,34 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ErrorMessageComponent} from './error.message.component';
+import {By} from '@angular/platform-browser';
+
+describe('ErrorMessageComponent', () => {
+  let component: ErrorMessageComponent;
+  let fixture: ComponentFixture<ErrorMessageComponent>;
+
+  beforeEach(async(() => {
+    return TestBed.configureTestingModule({
+      declarations: [
+        ErrorMessageComponent,
+      ],
+      imports: []
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ErrorMessageComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the message', () => {
+    component.errorMessage = 'errorx';
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('.error-message')).nativeElement.textContent).toBe('errorx');
+  });
+
+});

--- a/projects/media-viewer/src/lib/media-viewer/viewers/error-message/error.message.component.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/error-message/error.message.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'mv-error-message',
+  templateUrl: './error-message.component.html',
+  styleUrls: ['./error-message.component.scss']
+})
+export class ErrorMessageComponent {
+
+  @Input() errorMessage: string;
+
+}

--- a/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.html
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.html
@@ -1,5 +1,5 @@
 <div id="viewer-wrapper">
-  <div *ngIf="!errorMessage" id="image-container" [ngStyle]="{ transform: zoomStyle }">
+  <div *ngIf="!errorMessage" id="image-container" class="image-container" [ngStyle]="{ transform: zoomStyle }">
     <img #img *ngIf="url" data-hook="dm.viewer.img" [src]="url" [ngStyle]="{ transform: rotationStyle }" (error)="onLoadError()"/>
   </div>
   <mv-error-message *ngIf="errorMessage" [errorMessage]="errorMessage"></mv-error-message>

--- a/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.html
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.html
@@ -1,5 +1,6 @@
 <div id="viewer-wrapper">
-  <div id="image-container" [ngStyle]="{ transform: zoomStyle }">
-    <img #img *ngIf="url" data-hook="dm.viewer.img" [src]="url" [ngStyle]="{ transform: rotationStyle }"/>
+  <div *ngIf="!errorMessage" id="image-container" [ngStyle]="{ transform: zoomStyle }">
+    <img #img *ngIf="url" data-hook="dm.viewer.img" [src]="url" [ngStyle]="{ transform: rotationStyle }" (error)="onLoadError()"/>
   </div>
+  <mv-error-message *ngIf="errorMessage" [errorMessage]="errorMessage"></mv-error-message>
 </div>

--- a/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.spec.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.spec.ts
@@ -12,6 +12,7 @@ import {
 import { PrintService } from '../../service/print.service';
 import {ErrorMessageComponent} from '../error-message/error.message.component';
 import {By} from '@angular/platform-browser';
+import {SimpleChange} from '@angular/core';
 
 describe('ImageViewerComponent', () => {
   let component: ImageViewerComponent;
@@ -125,6 +126,20 @@ describe('ImageViewerComponent', () => {
     fixture.detectChanges();
     expect(fixture.debugElement.query(By.css('.image-container'))).toBeNull();
     expect(fixture.debugElement.query(By.directive(ErrorMessageComponent))).toBeTruthy();
+  });
+
+  it('when url changes the error message is reset', async () => {
+    component.errorMessage = 'errox';
+    component.url = 'x';
+    component.ngOnChanges({
+      url: new SimpleChange('a', 'b', true)
+    });
+    expect(component.errorMessage).toBeNull();
+  });
+
+  it('on load error show error message', () => {
+    component.onLoadError();
+    expect(component.errorMessage).toContain('Could not load the image');
   });
 });
 

--- a/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.spec.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.spec.ts
@@ -10,6 +10,7 @@ import {
   ZoomValue
 } from '../../model/viewer-operations';
 import { PrintService } from '../../service/print.service';
+import {ErrorMessageComponent} from '../error-message/error.message.component';
 
 describe('ImageViewerComponent', () => {
   let component: ImageViewerComponent;
@@ -20,6 +21,7 @@ describe('ImageViewerComponent', () => {
   beforeEach(async(() => {
     return TestBed.configureTestingModule({
       declarations: [
+        ErrorMessageComponent,
         ImageViewerComponent
       ]
     })

--- a/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.spec.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '../../model/viewer-operations';
 import { PrintService } from '../../service/print.service';
 import {ErrorMessageComponent} from '../error-message/error.message.component';
+import {By} from '@angular/platform-browser';
 
 describe('ImageViewerComponent', () => {
   let component: ImageViewerComponent;
@@ -115,6 +116,15 @@ describe('ImageViewerComponent', () => {
     expect(document.createElement).toHaveBeenCalledWith('a');
     expect(anchor.href).toContain(DOCUMENT_URL);
     expect(anchor.download).toBe('download-filename');
+  });
+
+  it('when errorMessage available show error message', () => {
+    expect(fixture.debugElement.query(By.css('.image-container')).nativeElement.className).not.toContain('hidden');
+    expect(fixture.debugElement.query(By.directive(ErrorMessageComponent))).toBe(null);
+    component.errorMessage = 'errorx';
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('.image-container'))).toBeNull();
+    expect(fixture.debugElement.query(By.directive(ErrorMessageComponent))).toBeTruthy();
   });
 });
 

--- a/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/image-viewer/image-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, ViewChild } from '@angular/core';
+import {Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild} from '@angular/core';
 import { PrintService } from '../../service/print.service';
 import { Subject } from 'rxjs';
 import {
@@ -15,11 +15,13 @@ import {
     templateUrl: './image-viewer.component.html',
     styleUrls: ['./image-viewer.component.scss'],
 })
-export class ImageViewerComponent {
+export class ImageViewerComponent implements OnChanges{
 
   @Input() url: string;
   @Input() downloadFileName: string;
   @Input() zoomValue: Subject<ZoomValue>;
+
+  errorMessage: string;
 
   @ViewChild('img') img: ElementRef;
   rotation = 0;
@@ -28,6 +30,12 @@ export class ImageViewerComponent {
   zoomStyle;
 
   constructor(private printService: PrintService) {
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.url) {
+      this.errorMessage = null;
+    }
   }
 
 
@@ -94,5 +102,9 @@ export class ImageViewerComponent {
     if (newZoomValue > 5) { return 5; }
     if (newZoomValue < 0.1) { return 0.1; }
     return newZoomValue;
+  }
+
+  onLoadError() {
+    this.errorMessage = `Could not load the image "${this.url}"`;
   }
 }

--- a/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-js/pdf-js-wrapper.provider.spec.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-js/pdf-js-wrapper.provider.spec.ts
@@ -2,6 +2,7 @@ import { PdfJsWrapperFactory } from './pdf-js-wrapper.provider';
 import { PdfViewerComponent } from '../pdf-viewer.component';
 import { EmLoggerService } from '../../../../logging/em-logger.service';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {ErrorMessageComponent} from '../../error-message/error.message.component';
 
 describe('PdfJsWrapperFactory', () => {
   let component: PdfViewerComponent;
@@ -9,7 +10,7 @@ describe('PdfJsWrapperFactory', () => {
 
   beforeEach(async(() => {
     return TestBed.configureTestingModule({
-      declarations: [ PdfViewerComponent ],
+      declarations: [ PdfViewerComponent, ErrorMessageComponent ],
       providers: [
         EmLoggerService,
         PdfJsWrapperFactory

--- a/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-viewer.component.html
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-viewer.component.html
@@ -1,5 +1,6 @@
-<div #viewerContainer class="pdfContainer" style="height: 99%; position: absolute" >
+<div #viewerContainer class="pdfContainer" style="height: 99%; position: absolute" [ngClass]="{hidden: errorMessage}">
   <div class="pdfViewer" [ngClass]="{hidden: loadingDocument}"></div>
   <div class="loadingMessage" [ngClass]="{hidden: !loadingDocument}">Loading...{{ loadingDocumentProgress ? loadingDocumentProgress + '%' : '' }}</div>
 </div>
+<mv-error-message [errorMessage]="errorMessage" *ngIf="errorMessage"></mv-error-message>
 

--- a/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-viewer.component.spec.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-viewer.component.spec.ts
@@ -17,6 +17,7 @@ import {
 import { PrintService } from '../../service/print.service';
 import {SimpleChange} from '@angular/core';
 import {ErrorMessageComponent} from '../error-message/error.message.component';
+import {By} from '@angular/platform-browser';
 
 describe('PdfViewerComponent', () => {
   let component: PdfViewerComponent;
@@ -158,5 +159,14 @@ describe('PdfViewerComponent', () => {
     expect(component.loadingDocumentProgress).toBe(90);
     mockWrapper.documentLoadProgress.next(new DocumentLoadProgress(200, 100));
     expect(component.loadingDocumentProgress).toBe(100);
+  });
+
+  it('when errorMessage available show error message', () => {
+    expect(fixture.debugElement.query(By.css('.pdfContainer')).nativeElement.className).not.toContain('hidden');
+    expect(fixture.debugElement.query(By.directive(ErrorMessageComponent))).toBeNull();
+    component.errorMessage = 'errorx';
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('.pdfContainer')).nativeElement.className).toContain('hidden');
+    expect(fixture.debugElement.query(By.directive(ErrorMessageComponent))).toBeTruthy();
   });
 });

--- a/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-viewer.component.spec.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-viewer.component.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '../../model/viewer-operations';
 import { PrintService } from '../../service/print.service';
 import {SimpleChange} from '@angular/core';
+import {ErrorMessageComponent} from '../error-message/error.message.component';
 
 describe('PdfViewerComponent', () => {
   let component: PdfViewerComponent;
@@ -49,7 +50,7 @@ describe('PdfViewerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ PdfViewerComponent ]
+      declarations: [ PdfViewerComponent, ErrorMessageComponent ]
     })
     .overrideComponent(PdfViewerComponent, {
       set: {

--- a/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-viewer.component.spec.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-viewer.component.spec.ts
@@ -169,4 +169,10 @@ describe('PdfViewerComponent', () => {
     expect(fixture.debugElement.query(By.css('.pdfContainer')).nativeElement.className).toContain('hidden');
     expect(fixture.debugElement.query(By.directive(ErrorMessageComponent))).toBeTruthy();
   });
+
+  it('on document load failed expect error message', () => {
+    mockWrapper.documentLoadFailed.next(new DocumentLoadFailed());
+    expect(component.errorMessage).toContain('Could not load the document');
+    expect(component.loadingDocument).toBe(false);
+  });
 });

--- a/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-viewer.component.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/pdf-viewer/pdf-viewer.component.ts
@@ -31,6 +31,7 @@ export class PdfViewerComponent implements AfterViewInit, OnChanges {
 
   loadingDocument = false;
   loadingDocumentProgress: number;
+  errorMessage: string;
 
   @ViewChild('viewerContainer') viewerContainer: ElementRef;
 
@@ -62,6 +63,7 @@ export class PdfViewerComponent implements AfterViewInit, OnChanges {
   private onDocumentLoadInit() {
     this.loadingDocument = true;
     this.loadingDocumentProgress = null;
+    this.errorMessage = null;
   }
 
   private onDocumentLoadProgress(documentLoadProgress: DocumentLoadProgress) {
@@ -76,6 +78,7 @@ export class PdfViewerComponent implements AfterViewInit, OnChanges {
 
   private onDocumentLoadFailed() {
     this.loadingDocument = false;
+    this.errorMessage = `Could not load the document "${this.url}"`;
   }
 
   @Input()

--- a/projects/media-viewer/src/lib/media-viewer/viewers/unsupported-viewer/unsupported-viewer.component.spec.ts
+++ b/projects/media-viewer/src/lib/media-viewer/viewers/unsupported-viewer/unsupported-viewer.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { UnsupportedViewerComponent } from './unsupported-viewer.component';
 import { DownloadOperation } from '../../model/viewer-operations';
+import {ErrorMessageComponent} from '../error-message/error.message.component';
 
 describe('UnsupportedViewerComponent', () => {
   let component: UnsupportedViewerComponent;
@@ -9,7 +10,7 @@ describe('UnsupportedViewerComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ UnsupportedViewerComponent ]
+      declarations: [ UnsupportedViewerComponent, ErrorMessageComponent ]
     })
     .compileComponents();
   }));


### PR DESCRIPTION

### JIRA link (if applicable) ###
EM-1635


### Change description ###

Added ErrorMessageComponent to be used by individual Renderers in case of an Error. 
It's used when on-load exception is thrown by pdf-js and when onerror is invoked by img (ImageViewer)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
