### PR TITLE
fix comment editing

### DIFF
--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.spec.ts
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.spec.ts
@@ -88,7 +88,6 @@ describe('AnnotationSetComponent', () => {
 
     component.newRectangle = new ElementRef(document.createElement('div'));
     component.drawMode = true;
-    component.selected = 1;
     component.onMouseDown({ pageY: 10, pageX: 10 } as MouseEvent);
     component.onMouseMove({ pageY: 100, pageX: 100 } as MouseEvent);
     component.onMouseUp();
@@ -96,7 +95,6 @@ describe('AnnotationSetComponent', () => {
     expect(spy).toHaveBeenCalled();
 
     expect(component.annotationSet.annotations[component.annotationSet.annotations.length - 1].id).toEqual('new');
-    expect(component.selected).toEqual(-1);
   });
 
 });

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.ts
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.ts
@@ -59,8 +59,6 @@ export class AnnotationSetComponent {
       this.newRectangle.nativeElement.style.top =  this.drawStartY + 'px';
       this.newRectangle.nativeElement.style.left = this.drawStartX + 'px';
     }
-
-    return false;
   }
 
   public onMouseMove(event: MouseEvent) {
@@ -70,8 +68,6 @@ export class AnnotationSetComponent {
       this.newRectangle.nativeElement.style.width =
         (event.pageX - this.drawStartX - (window.scrollX + this.container.nativeElement.getBoundingClientRect().left)) + 'px';
     }
-
-    return false;
   }
 
   public onMouseUp() {
@@ -103,11 +99,6 @@ export class AnnotationSetComponent {
       this.newRectangle.nativeElement.style.display = 'none';
       this.newRectangle.nativeElement.style.width = '0';
       this.newRectangle.nativeElement.style.height = '0';
-
     }
-
-    this.selected = -1;
-
-    return false;
   }
 }

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation/annotation.component.html
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation/annotation.component.html
@@ -1,7 +1,7 @@
-<div class="annotation-wrapper" tabindex="1" (focusout)="toggleSelection(false)">
+<div #container class="annotation-wrapper" tabindex="1" (focusout)="onFocusOut($event)">
   <ng-container *ngFor="let rectangle of annotation.rectangles">
     <mv-anno-rectangle
-      (click)="toggleSelection(true)"
+      (click)="onSelect()"
       (update)="onRectangleUpdate($event)"
       [selected]="selected"
       [zoom]="zoom"
@@ -13,7 +13,7 @@
   </ng-container>
   <mv-anno-comment
     *ngIf="annotation.comments[0]"
-    (click)="toggleSelection(true)"
+    (click)="onSelect()"
     (delete)="onCommentDelete()"
     (updated)="onCommentUpdate($event)"
     [rotate]="rotate"

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation/annotation.component.spec.ts
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation/annotation.component.spec.ts
@@ -46,7 +46,19 @@ describe('AnnotationComponent', () => {
         expect(selected).toBe(true);
         resolve();
       });
-      component.toggleSelection(true);
+      component.onSelect();
+    });
+  });
+
+  it('deselect the annotation', async () => {
+    await new Promise(resolve => {
+      component.select.subscribe(selected => {
+        expect(selected).toBe(false);
+        resolve();
+      });
+
+      const relatedTarget = document.createElement('span');
+      component.onFocusOut({ relatedTarget } as any);
     });
   });
 

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation/annotation.component.ts
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation/annotation.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewChild, ElementRef } from '@angular/core';
 import { Annotation } from './annotation.model';
 import { Rectangle } from './rectangle/rectangle.model';
 
@@ -18,8 +18,10 @@ export class AnnotationComponent {
   @Output() update = new EventEmitter<Annotation>();
   @Output() select = new EventEmitter<boolean>();
 
-  public toggleSelection(selected: boolean) {
-    this.select.emit(selected);
+  @ViewChild('container') container: ElementRef;
+
+  public onSelect() {
+    this.select.emit(true);
   }
 
   public onCommentDelete() {
@@ -37,5 +39,11 @@ export class AnnotationComponent {
     this.annotation.rectangles.push(rectangle);
 
     this.update.emit(this.annotation);
+  }
+
+  public onFocusOut(event: FocusEvent) {
+    if (!this.container.nativeElement.contains(event.relatedTarget)) {
+      this.select.emit(false);
+    }
   }
 }


### PR DESCRIPTION
This PR changes the mouse event handling in the AnnotationSet component so that the comment editing correctly focuses. I'm not quite sure why an event handler higher in the event change was able to block one lower down but that's the way it seemed to work.