### PR TITLE
Feature/em 2189 select text native and annotations

### DIFF
--- a/projects/media-viewer/src/assets/sass/annotation-ui-theme.scss
+++ b/projects/media-viewer/src/assets/sass/annotation-ui-theme.scss
@@ -15,14 +15,6 @@
     margin-bottom: 10px;
   }
 
-  .annotationLayer {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-  }
-
   .pdfViewer .page {
     border-image: none;
   }

--- a/projects/media-viewer/src/assets/sass/annotation-ui-theme.scss
+++ b/projects/media-viewer/src/assets/sass/annotation-ui-theme.scss
@@ -15,6 +15,14 @@
     margin-bottom: 10px;
   }
 
+  .annotationLayer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+
   .pdfViewer .page {
     border-image: none;
   }

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.html
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.html
@@ -1,5 +1,5 @@
 <div #container
-     [ngClass]="'rotation rot' + rotate"
+     [ngClass]="annotationSetClass()"
      [style.width]="width ? (width + 'px') : '100%'"
      [style.height]="height ? (height + 'px') : '100%'"
      (mousedown)="onMouseDown($event)"

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.scss
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.scss
@@ -1,7 +1,3 @@
-.drawMode {
-  z-index: 4;
-}
-
 .rotation {
   -webkit-transform-origin: left bottom;
   -moz-transform-origin: left bottom;
@@ -55,3 +51,8 @@
   opacity: 0.5;
   background-color: yellow;
 }
+
+.drawMode, .rot90, .rot180, .rot270 {
+  z-index: 4;
+}
+

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.scss
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.scss
@@ -1,3 +1,6 @@
+.drawMode {
+  z-index: 3 !important;
+}
 
 .rotation {
   -webkit-transform-origin: left bottom;

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.scss
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.scss
@@ -1,5 +1,5 @@
 .drawMode {
-  z-index: 3 !important;
+  z-index: 4;
 }
 
 .rotation {

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.spec.ts
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.spec.ts
@@ -343,4 +343,18 @@ describe('AnnotationSetComponent', () => {
 
     expect(newRectPos).toEqual({ top: 90, left: 90, height: 10, width: 10 });
   });
+
+  it('should return the correct class values', async () => {
+    component.drawMode = false;
+    component.rotate = 0;
+
+    let className = component.annotationSetClass();
+    expect(className).toEqual(['rotation rot0', '']);
+
+    component.drawMode = true;
+    component.rotate = 90;
+
+    className = component.annotationSetClass();
+    expect(className).toEqual(['rotation rot90', 'drawMode']);
+  });
 });

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.ts
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.ts
@@ -312,7 +312,7 @@ export class AnnotationSetComponent implements OnInit, OnDestroy {
   annotationSetClass() {
     return [
       'rotation rot' + this.rotate,
-      this.drawMode ? ' drawMode' : ''
+      this.drawMode ? 'drawMode' : ''
     ];
   }
 }

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.ts
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation-set.component.ts
@@ -308,4 +308,11 @@ export class AnnotationSetComponent implements OnInit, OnDestroy {
       width: width
     };
   }
+
+  annotationSetClass() {
+    return [
+      'rotation rot' + this.rotate,
+      this.drawMode ? ' drawMode' : ''
+    ];
+  }
 }

--- a/projects/media-viewer/src/lib/annotations/annotation-set/annotation/rectangle/rectangle.component.scss
+++ b/projects/media-viewer/src/lib/annotations/annotation-set/annotation/rectangle/rectangle.component.scss
@@ -1,6 +1,6 @@
 .rectangle {
   position: absolute;
-  z-index: 2;
+  z-index: 3;
   opacity: 0.3;
   cursor: move; /* fallback if grab cursor is unsupported */
   cursor: grab;

--- a/projects/media-viewer/src/lib/viewers/pdf-viewer/pdf-viewer.component.scss
+++ b/projects/media-viewer/src/lib/viewers/pdf-viewer/pdf-viewer.component.scss
@@ -48,7 +48,6 @@
 }
 
 .textLayer {
-  position: absolute;
   z-index: 1;
 }
 

--- a/projects/media-viewer/src/lib/viewers/pdf-viewer/pdf-viewer.component.scss
+++ b/projects/media-viewer/src/lib/viewers/pdf-viewer/pdf-viewer.component.scss
@@ -47,6 +47,10 @@
   opacity: 0.0 !important;
 }
 
-.annotationLayer section {
-  z-index: 2!important;
+.textLayer {
+  z-index: 1 !important;
+}
+
+.annotationLayer * {
+  z-index: 2 !important;
 }

--- a/projects/media-viewer/src/lib/viewers/pdf-viewer/pdf-viewer.component.scss
+++ b/projects/media-viewer/src/lib/viewers/pdf-viewer/pdf-viewer.component.scss
@@ -48,9 +48,10 @@
 }
 
 .textLayer {
-  z-index: 1 !important;
+  position: absolute;
+  z-index: 1;
 }
 
 .annotationLayer * {
-  z-index: 2 !important;
+  z-index: 2;
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-2189


### Change description ###
To allow text and native annotation to be selected when annotations are created. There is an issue when rotated that the transform style used to rotated the annotation set effect layering/z index, therefore the feature is only allowed when in original position.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
