### PR TITLE
fix counter clockwise image rotation

### DIFF
--- a/projects/media-viewer/src/lib/toolbar/main-toolbar/main-toolbar.component.html
+++ b/projects/media-viewer/src/lib/toolbar/main-toolbar/main-toolbar.component.html
@@ -100,7 +100,7 @@
             aria-pressed="false" [class.button-hidden-on-toolbar]="mvToolbarMain.offsetWidth < widthRequiredForBtn['mvRotateBtn']"
             [class.button-hidden-on-dropdown]="mvToolbarMain.offsetWidth >= widthRequiredForBtn['mvRotateBtn']">
             <button id="mvRotateLeftBtn" class="mv-toolbar__menu-button--rotate_left button-image"
-              title="Rotate Counterclockwise" data-l10n-id="page_rotate_ccw" (click)="rotate(-90)"><span></span>
+              title="Rotate Counterclockwise" data-l10n-id="page_rotate_ccw" (click)="rotate(270)"><span></span>
             </button>
             <button id="mvRotateRightBtn" class="mv-toolbar__menu-button--rotate_right button-image"
               title="Rotate Clockwise" data-l10n-id="page_rotate_cw" (click)="rotate(90)"><span></span>

--- a/projects/media-viewer/src/lib/toolbar/main-toolbar/main-toolbar.component.spec.ts
+++ b/projects/media-viewer/src/lib/toolbar/main-toolbar/main-toolbar.component.spec.ts
@@ -194,7 +194,7 @@ describe('MainToolbarComponent', () => {
     const rotateCtrClkwiseBtn = nativeElement.querySelector('button[id=mvRotateLeftBtn]');
     rotateCtrClkwiseBtn.click();
 
-    expect(rotateSpy).toHaveBeenCalledWith(-90);
+    expect(rotateSpy).toHaveBeenCalledWith(270);
   });
 
   it('should emit zoom out event', () => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-3256

### Change description ###
- fix counter clockwise image rotation by using 270 instead of -90


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
